### PR TITLE
add covid som (diagnostic) data

### DIFF
--- a/code_schemes/diagnostic_s01e01.json
+++ b/code_schemes/diagnostic_s01e01.json
@@ -1,0 +1,451 @@
+{
+    "SchemeID": "Scheme-03bb299c",
+    "Name": "Diagnostic S01E01",
+    "Version": "0.0.0.1",
+    "Codes": [
+      {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-Q-a5d3700d",
+        "CodeType": "Meta",
+        "MetaCode": "question",
+        "DisplayText": "meta: question",
+        "NumericValue": -100010,
+        "StringValue": "question",
+        "VisibleInCoda": true,
+        "Shortcut": "q"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "CodeID": "code-7c9ad462",
+        "CodeType": "Normal",
+        "DisplayText": "knowledge",
+        "NumericValue": 1,
+        "StringValue": "knowledge",
+        "VisibleInCoda": true,
+        "Shortcut": "k"
+      },
+      {
+        "CodeID": "code-764d0175",
+        "CodeType": "Normal",
+        "DisplayText": "attitude",
+        "NumericValue": 2,
+        "StringValue": "attitude",
+        "VisibleInCoda": true,
+        "Shortcut": "m"
+      },
+      {
+        "CodeID": "code-bc54d371",
+        "CodeType": "Normal",
+        "DisplayText": "behaviour",
+        "NumericValue": 3,
+        "StringValue": "behaviour",
+        "VisibleInCoda": true,
+        "Shortcut": "o"
+      },
+      {
+        "CodeID": "code-27b64369",
+        "CodeType": "Normal",
+        "DisplayText": "about coronavirus",
+        "NumericValue": 4,
+        "StringValue": "about_coronavirus",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-d606d1e8",
+        "CodeType": "Normal",
+        "DisplayText": "symptoms",
+        "NumericValue": 5,
+        "StringValue": "symptoms",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-34979c11",
+        "CodeType": "Normal",
+        "DisplayText": "how to prevent",
+        "NumericValue": 6,
+        "StringValue": "how_to_prevent",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-6feb376a",
+        "CodeType": "Normal",
+        "DisplayText": "how to treat",
+        "NumericValue": 7,
+        "StringValue": "how_to_treat",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-9ec1af3e",
+        "CodeType": "Normal",
+        "DisplayText": "how spread/transmitted",
+        "NumericValue": 8,
+        "StringValue": "how_spread_transmitted",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-eeb68475",
+        "CodeType": "Normal",
+        "DisplayText": "what is govt policy",
+        "NumericValue": 9,
+        "StringValue": "what_is_govt_policy",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-e44f75d6",
+        "CodeType": "Normal",
+        "DisplayText": "somalia update",
+        "NumericValue": 10,
+        "StringValue": "somalia_update",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-470524f3",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/stigma/misinfo",
+        "NumericValue": 11,
+        "StringValue": "rumour_stigma_misinfo",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-5dba1303",
+        "CodeType": "Normal",
+        "DisplayText": "government responce",
+        "NumericValue": 12,
+        "StringValue": "government_responce",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-749d19f3",
+        "CodeType": "Normal",
+        "DisplayText": "collective hope",
+        "NumericValue": 13,
+        "StringValue": "collective_hope",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-08da7dd0",
+        "CodeType": "Normal",
+        "DisplayText": "anxiety/panic",
+        "NumericValue": 14,
+        "StringValue": "anxiety_panic",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-af9e420d",
+        "CodeType": "Normal",
+        "DisplayText": "other theme",
+        "NumericValue": 15,
+        "StringValue": "other_theme",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-6f06a828",
+        "CodeType": "Normal",
+        "DisplayText": "religious hope/practice",
+        "NumericValue": 16,
+        "StringValue": "religious_hope_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-00879b71",
+        "CodeType": "Normal",
+        "DisplayText": "denial",
+        "NumericValue": 17,
+        "StringValue": "denial",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-e1ca99b8",
+        "CodeType": "Normal",
+        "DisplayText": "humanitarian aid",
+        "NumericValue": 18,
+        "StringValue": "humanitarian_aid",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-b1a79833",
+        "CodeType": "Normal",
+        "DisplayText": "call for awareness creation",
+        "NumericValue": 19,
+        "StringValue": "call_for_awareness_creation",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-507efe67",
+        "CodeType": "Normal",
+        "DisplayText": "call for right practice",
+        "NumericValue": 20,
+        "StringValue": "call_for_right_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-476ffa58",
+        "CodeType": "Normal",
+        "DisplayText": "right practice - general follow advice",
+        "NumericValue": 21,
+        "StringValue": "right_practice_general_follow_advice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-09effcec",
+        "CodeType": "Normal",
+        "DisplayText": "right practice - distancing/isolation/quarantine",
+        "NumericValue": 22,
+        "StringValue": "right_practice_distancing_isolation_quarantine",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-1015dd8b",
+        "CodeType": "Normal",
+        "DisplayText": "right practice - hygiene",
+        "NumericValue": 23,
+        "StringValue": "right_practice_hygiene",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-c5aeea34",
+        "CodeType": "Normal",
+        "DisplayText": "right practice - multiple",
+        "NumericValue": 24,
+        "StringValue": "right_practice_multiple",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-c8bfc31a",
+        "CodeType": "Normal",
+        "DisplayText": "religion - practice",
+        "NumericValue": 25,
+        "StringValue": "religion_practice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-bb675fc3",
+        "CodeType": "Normal",
+        "DisplayText": "religion - guidance",
+        "NumericValue": 26,
+        "StringValue": "religion_guidance",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-a285c512",
+        "CodeType": "Normal",
+        "DisplayText": "religion - hope and fate",
+        "NumericValue": 27,
+        "StringValue": "religion_hope_and_fate",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-fd9b6659",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/misinfo - therapies/cures",
+        "NumericValue": 28,
+        "StringValue": "rumour_misinfo_therapies_cures",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-afbc1636",
+        "CodeType": "Normal",
+        "DisplayText": "stigma - hostility/rejection/anger",
+        "NumericValue": 29,
+        "StringValue": "stigma_hostility_rejection_anger",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-126a6e63",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/misinfo - cause misunderstood",
+        "NumericValue": 30,
+        "StringValue": "rumour_misinfo_cause_misunderstood",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NA-f93d3eb7",
+        "CodeType": "Control",
+        "ControlCode": "NA",
+        "DisplayText": "NA (missing)",
+        "NumericValue": -10,
+        "StringValue": "NA",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NS-2c11b7c9",
+        "CodeType": "Control",
+        "ControlCode": "NS",
+        "DisplayText": "NS (skip)",
+        "NumericValue": -20,
+        "StringValue": "NS",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NC-42f1d983",
+        "CodeType": "Control",
+        "ControlCode": "NC",
+        "DisplayText": "NC (not coded)",
+        "NumericValue": -30,
+        "StringValue": "NC",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NR-5e3eee23",
+        "CodeType": "Control",
+        "ControlCode": "NR",
+        "DisplayText": "NR (not reviewed)",
+        "NumericValue": -40,
+        "StringValue": "NR",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NIC-99631cb8",
+        "CodeType": "Control",
+        "ControlCode": "NIC",
+        "DisplayText": "NIC (not internally consistent)",
+        "NumericValue": -50,
+        "StringValue": "NIC",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-STOP-08b832a8",
+        "CodeType": "Control",
+        "ControlCode": "STOP",
+        "DisplayText": "STOP",
+        "NumericValue": -90,
+        "StringValue": "STOP",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-WS-adb25603b7af",
+        "CodeType": "Control",
+        "ControlCode": "WS",
+        "DisplayText": "WS (wrong scheme)",
+        "NumericValue": -100,
+        "StringValue": "WS",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-CE-016c1e22",
+        "CodeType": "Control",
+        "ControlCode": "CE",
+        "DisplayText": "CE (coding error)",
+        "NumericValue": -110,
+        "StringValue": "CE",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-PB-a434a800",
+        "CodeType": "Meta",
+        "MetaCode": "push_back",
+        "DisplayText": "meta: push back",
+        "NumericValue": -100000,
+        "StringValue": "push_back",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SQ-5e8f0122",
+        "CodeType": "Meta",
+        "MetaCode": "showtime_question",
+        "DisplayText": "meta: showtime question",
+        "NumericValue": -100030,
+        "StringValue": "showtime_question",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-G-97cb3199",
+        "CodeType": "Meta",
+        "MetaCode": "greeting",
+        "DisplayText": "meta: greeting",
+        "NumericValue": -100020,
+        "StringValue": "greeting",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-OI-c5f1d054",
+        "CodeType": "Meta",
+        "MetaCode": "opt-in",
+        "DisplayText": "meta: opt-in",
+        "NumericValue": -100040,
+        "StringValue": "opt_in",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SC-a3a065bc",
+        "CodeType": "Meta",
+        "MetaCode": "similar_content",
+        "DisplayText": "meta: similar content",
+        "NumericValue": -100050,
+        "StringValue": "similar_content",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-PI-83b90d32",
+        "CodeType": "Meta",
+        "MetaCode": "participation_incentive",
+        "DisplayText": "meta: participation incentive",
+        "NumericValue": -100060,
+        "StringValue": "participation_incentive",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-EC-3a704f5b",
+        "CodeType": "Meta",
+        "MetaCode": "exclusion_complaint",
+        "DisplayText": "meta: exclusion complaint",
+        "NumericValue": -100070,
+        "StringValue": "exclusion_complaint",
+        "VisibleInCoda": true
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": false,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": false,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": false
+      }
+    ]
+}

--- a/code_schemes/diagnostic_s01e02.json
+++ b/code_schemes/diagnostic_s01e02.json
@@ -1,0 +1,272 @@
+{
+    "SchemeID": "Scheme-18dbab04",
+    "Name": "Diagnostic S01E02",
+    "Version": "0.0.0.1",
+    "Codes": [
+      {
+        "CodeID": "code-E-720cdb66",
+        "CodeType": "Meta",
+        "MetaCode": "escalate",
+        "DisplayText": "meta: ESCALATE",
+        "NumericValue": -100080,
+        "StringValue": "escalate",
+        "VisibleInCoda": true,
+        "Shortcut": "e"
+      },
+      {
+        "CodeID": "code-Q-a5d3700d",
+        "CodeType": "Meta",
+        "MetaCode": "question",
+        "DisplayText": "meta: question",
+        "NumericValue": -100010,
+        "StringValue": "question",
+        "VisibleInCoda": true,
+        "Shortcut": "q"
+      },
+      {
+        "CodeID": "code-S-461bfcdf",
+        "CodeType": "Meta",
+        "MetaCode": "statement",
+        "DisplayText": "meta: statement",
+        "NumericValue": -100090,
+        "StringValue": "statement",
+        "VisibleInCoda": true,
+        "Shortcut": "s"
+      },
+      {
+        "CodeID": "code-57aeb565",
+        "CodeType": "Normal",
+        "DisplayText": "unclear whose advice",
+        "NumericValue": 1,
+        "StringValue": "unclear_whose_advice",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-51881163",
+        "CodeType": "Normal",
+        "DisplayText": "prayer",
+        "NumericValue": 2,
+        "StringValue": "prayer",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-73db94b0",
+        "CodeType": "Normal",
+        "DisplayText": "follow the advice of the government",
+        "NumericValue": 3,
+        "StringValue": "follow_the_advice_of_the_government",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-9c765886",
+        "CodeType": "Normal",
+        "DisplayText": "denial",
+        "NumericValue": 4,
+        "StringValue": "denial",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-d04669f3",
+        "CodeType": "Normal",
+        "DisplayText": "rumour/misinfo",
+        "NumericValue": 5,
+        "StringValue": "rumour_misinfo",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-67d1a441",
+        "CodeType": "Normal",
+        "DisplayText": "protect the vulnerable",
+        "NumericValue": 6,
+        "StringValue": "protect_the_vulnerable",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-aeedb431",
+        "CodeType": "Normal",
+        "DisplayText": "negative stigma",
+        "NumericValue": 8,
+        "StringValue": "negative_stigma",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-dd71e8fe",
+        "CodeType": "Normal",
+        "DisplayText": "other theme",
+        "NumericValue": 7,
+        "StringValue": "other_theme",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NA-f93d3eb7",
+        "CodeType": "Control",
+        "ControlCode": "NA",
+        "DisplayText": "NA (missing)",
+        "NumericValue": -10,
+        "StringValue": "NA",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NS-2c11b7c9",
+        "CodeType": "Control",
+        "ControlCode": "NS",
+        "DisplayText": "NS (skip)",
+        "NumericValue": -20,
+        "StringValue": "NS",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NC-42f1d983",
+        "CodeType": "Control",
+        "ControlCode": "NC",
+        "DisplayText": "NC (not coded)",
+        "NumericValue": -30,
+        "StringValue": "NC",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NR-5e3eee23",
+        "CodeType": "Control",
+        "ControlCode": "NR",
+        "DisplayText": "NR (not reviewed)",
+        "NumericValue": -40,
+        "StringValue": "NR",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NIC-99631cb8",
+        "CodeType": "Control",
+        "ControlCode": "NIC",
+        "DisplayText": "NIC (not internally consistent)",
+        "NumericValue": -50,
+        "StringValue": "NIC",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-STOP-08b832a8",
+        "CodeType": "Control",
+        "ControlCode": "STOP",
+        "DisplayText": "STOP",
+        "NumericValue": -90,
+        "StringValue": "STOP",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-WS-adb25603b7af",
+        "CodeType": "Control",
+        "ControlCode": "WS",
+        "DisplayText": "WS (wrong scheme)",
+        "NumericValue": -100,
+        "StringValue": "WS",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-CE-016c1e22",
+        "CodeType": "Control",
+        "ControlCode": "CE",
+        "DisplayText": "CE (coding error)",
+        "NumericValue": -110,
+        "StringValue": "CE",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-PB-a434a800",
+        "CodeType": "Meta",
+        "MetaCode": "push_back",
+        "DisplayText": "meta: push back",
+        "NumericValue": -100000,
+        "StringValue": "push_back",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SQ-5e8f0122",
+        "CodeType": "Meta",
+        "MetaCode": "showtime_question",
+        "DisplayText": "meta: showtime question",
+        "NumericValue": -100030,
+        "StringValue": "showtime_question",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-G-97cb3199",
+        "CodeType": "Meta",
+        "MetaCode": "greeting",
+        "DisplayText": "meta: greeting",
+        "NumericValue": -100020,
+        "StringValue": "greeting",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-OI-c5f1d054",
+        "CodeType": "Meta",
+        "MetaCode": "opt-in",
+        "DisplayText": "meta: opt-in",
+        "NumericValue": -100040,
+        "StringValue": "opt_in",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SC-a3a065bc",
+        "CodeType": "Meta",
+        "MetaCode": "similar_content",
+        "DisplayText": "meta: similar content",
+        "NumericValue": -100050,
+        "StringValue": "similar_content",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-PI-83b90d32",
+        "CodeType": "Meta",
+        "MetaCode": "participation_incentive",
+        "DisplayText": "meta: participation incentive",
+        "NumericValue": -100060,
+        "StringValue": "participation_incentive",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-EC-3a704f5b",
+        "CodeType": "Meta",
+        "MetaCode": "exclusion_complaint",
+        "DisplayText": "meta: exclusion complaint",
+        "NumericValue": -100070,
+        "StringValue": "exclusion_complaint",
+        "VisibleInCoda": true
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": false,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": false,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": false
+      }
+    ]
+}

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -12,7 +12,7 @@ def _open_scheme(filename):
 class CodeSchemes(object):
     DIAGNOSTIC_S01E01 = _open_scheme("diagnostic_s01e01.json")
     DIAGNOSTIC_S01E02 = _open_scheme("diagnostic_s01e02.json")
-    IMAQAL_COVID19_S01E01 = _open_scheme("s01e01.json")
+    S01E01 = _open_scheme("s01e01.json")
 
     AGE = _open_scheme("age.json")
     AGE_CATEGORY = _open_scheme("age_category.json")

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -10,7 +10,9 @@ def _open_scheme(filename):
 
 
 class CodeSchemes(object):
-    S01E01 = _open_scheme("s01e01.json")
+    DIAGNOSTIC_S01E01 = _open_scheme("diagnostic_s01e01.json")
+    DIAGNOSTIC_S01E02 = _open_scheme("diagnostic_s01e02.json")
+    IMAQAL_COVID19_S01E01 = _open_scheme("s01e01.json")
 
     AGE = _open_scheme("age.json")
     AGE_CATEGORY = _open_scheme("age_category.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -71,10 +71,10 @@ def get_rqa_coding_plans(pipeline_name):
                    coding_configurations=[
                        CodingConfiguration(
                            coding_mode=CodingModes.MULTIPLE,
-                           code_scheme=CodeSchemes.IMAQAL_COVID19_S01E01,
+                           code_scheme=CodeSchemes.S01E01,
                            coded_field="rqa_covid19_mag_s01e01_coded",
                            analysis_file_key="rqa_covid19_mag_s01e01_",
-                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.IMAQAL_COVID19_S01E01, x, y)
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.S01E01, x, y)
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 s01e01"),

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -29,6 +29,40 @@ def clean_district_if_no_mogadishu_sub_district(text):
 
 def get_rqa_coding_plans(pipeline_name):
     return [
+        CodingPlan(raw_field="diagnostic_rqa_s01e01_raw",
+                   time_field="sent_on",
+                   run_id_field="diagnostic_rqa_s01e01_run_id",
+                   coda_filename="COVID19_SOM_s01e01.json",
+                   icr_filename="diagnostic_s01e01.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DIAGNOSTIC_S01E01,
+                           coded_field="diagnostic_rqa_s01e01_coded",
+                           analysis_file_key="diagnostic_rqa_s01e01_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DIAGNOSTIC_S01E01, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 som s01e01"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="diagnostic_rqa_s01e02_raw",
+                   time_field="sent_on",
+                   run_id_field="diagnostic_rqa_s01e02_run_id",
+                   coda_filename="COVID19_SOM_s01e02.json",
+                   icr_filename="diagnostic_s01e02.csv",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DIAGNOSTIC_S01E02,
+                           coded_field="diagnostic_rqa_s01e02_coded",
+                           analysis_file_key="diagnostic_rqa_s01e02_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DIAGNOSTIC_S01E02, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("covid19 som s01e02"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
         CodingPlan(raw_field="rqa_covid19_mag_s01e01_raw",
                    time_field="sent_on",
                    run_id_field="rqa_covid19_mag_s01e01_run_id",
@@ -37,10 +71,10 @@ def get_rqa_coding_plans(pipeline_name):
                    coding_configurations=[
                        CodingConfiguration(
                            coding_mode=CodingModes.MULTIPLE,
-                           code_scheme=CodeSchemes.S01E01,
+                           code_scheme=CodeSchemes.IMAQAL_COVID19_S01E01,
                            coded_field="rqa_covid19_mag_s01e01_coded",
                            analysis_file_key="rqa_covid19_mag_s01e01_",
-                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.S01E01, x, y)
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.IMAQAL_COVID19_S01E01, x, y)
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 s01e01"),

--- a/configuration/pipeline_config.json
+++ b/configuration/pipeline_config.json
@@ -7,6 +7,8 @@
       "TokenFileURL": "gs://avf-credentials/imaqal-text-it-token.txt",
       "ContactsFileName": "imaqal_covid19_contacts",
       "ActivationFlowNames": [
+        "covid19_som_s01e01_activation",
+        "covid19_som_s01e02_activation",
         "imaqal_covid19_mag_s01e01_activation"
       ],
       "SurveyFlowNames": [
@@ -26,6 +28,14 @@
   },
   "RapidProKeyRemappings": [
     {"RapidProKey": "avf_phone_id", "PipelineKey": "uid"},
+
+    {"RapidProKey": "Covid19_Som_Rqa_S01E01 (Text) - covid19_som_s01e01_activation", "PipelineKey": "diagnostic_rqa_s01e01_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Covid19_Som_Rqa_S01E01 (Run ID) - covid19_som_s01e01_activation", "PipelineKey": "diagnostic_rqa_s01e01_run_id"},
+    {"RapidProKey": "Covid19_Som_Rqa_S01E01 (Time) - covid19_som_s01e01_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Covid19_Som_Rqa_S01E02 (Text) - covid19_som_s01e02_activation", "PipelineKey": "diagnostic_rqa_s01e02_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Covid19_Som_Rqa_S01E02 (Run ID) - covid19_som_s01e02_activation", "PipelineKey": "diagnostic_rqa_s01e02_run_id"},
+    {"RapidProKey": "Covid19_Som_Rqa_S01E02 (Time) - covid19_som_s01e02_activation", "PipelineKey": "sent_on"},
 
     {"RapidProKey": "Rqa_Covid19_Mag_S01E01_Raw (Text) - imaqal_covid19_mag_s01e01_activation", "PipelineKey": "rqa_covid19_mag_s01e01_raw", "IsActivationMessage": true},
     {"RapidProKey": "Rqa_Covid19_Mag_S01E01_Raw (Run ID) - imaqal_covid19_mag_s01e01_activation", "PipelineKey": "rqa_covid19_mag_s01e01_run_id"},
@@ -53,7 +63,7 @@
     {"RapidProKey": "District (Value) - imaqal_covid19_demog", "PipelineKey": "location_raw"},
     {"RapidProKey": "District (Time) - imaqal_covid19_demog", "PipelineKey": "location_time"}
   ],
-  "ProjectStartDate": "2020-05-13T16:00:00+03:00",
+  "ProjectStartDate": "2020-04-03T16:40:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",
   "FilterTestMessages": true,
   "MoveWSMessages": false,

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -15,6 +15,8 @@ DATA_ROOT=$3
 ./checkout_coda_v2.sh "$CODA_V2_ROOT"
 
 DATASETS=(
+    "COVID19_SOM_s01e01"
+    "COVID19_SOM_s01e02"
     "IMAQAL_COVID19_s01e01"
 
     "IMAQAL_gender"


### PR DESCRIPTION
This allows us to add COVID-som pipeline data to the new project. Have used the term diagnostic where possible because that is the term the team refers to the initial pilot project. 
Will add imaqal-covid19 only inference on demand.