### PR TITLE
remove individual age variables from theme distribution

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
         survey_counts["Total Participants %"] = None
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None:
+                if cc.analysis_file_key is None or cc.code_scheme == CodeSchemes.AGE:
                     continue
 
                 for code in cc.code_scheme.codes:
@@ -236,7 +236,7 @@ if __name__ == "__main__":
     def update_survey_counts(survey_counts, td):
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None:
+                if cc.analysis_file_key is None or cc.code_scheme == CodeSchemes.AGE:
                     continue
 
                 if cc.coding_mode == CodingModes.SINGLE:
@@ -259,7 +259,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None:
+                if cc.analysis_file_key is None or cc.code_scheme == CodeSchemes.AGE:
                     continue
 
                 for code in cc.code_scheme.codes:


### PR DESCRIPTION
cleans up single age columns and leaves the age category which is what RDA are currently using. 