### PR TITLE
Small fixes to upload log files

### DIFF
--- a/run_scripts/8_upload_log_files.sh
+++ b/run_scripts/8_upload_log_files.sh
@@ -2,12 +2,18 @@
 
 set -e
 
+if [[ $# -ne 5 ]]; then
+    echo "Usage: ./8_upload_log_files.sh <user> <google-cloud-credentials-file-path> <pipeline-configuration-file-path> <memory-profile-dir> <data-archive-dir>"
+    echo "Uploads the pipeline's analysis files"
+    exit
+fi
+
 USER=$1
-AVF_BUCKET_CREDENTIALS_PATH=$2
+GOOGLE_CLOUD_CREDENTIALS_FILE_PATH=$2
 PIPELINE_CONFIGURATION_FILE_PATH=$3
 MEMORY_PROFILE_DIR=$4
 DATA_ARCHIVE_DIR=$5
 
 cd ..
-pipenv run python upload_log_files.py "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION_FILE_PATH" \
-      "$MEMORY_PROFILE_DIR" "$DATA_ARCHIVE_DIR"
+pipenv run python upload_log_files.py "$USER" "$GOOGLE_CLOUD_CREDENTIALS_FILE_PATH" "$PIPELINE_CONFIGURATION_FILE_PATH" \
+    "$MEMORY_PROFILE_DIR" "$DATA_ARCHIVE_DIR"

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -154,8 +154,10 @@ class PipelineConfiguration(object):
                 "drive_upload is not of type DriveUpload"
             self.drive_upload.validate()
 
-        memory_profile_upload_url_prefix = f"{self.memory_profile_upload_bucket}{self.bucket_dir_path}"
-        validators.validate_string(memory_profile_upload_url_prefix, "memory_profile_upload_url_prefix")
+        validators.validate_url(self.memory_profile_upload_bucket, "memory_profile_upload_bucket", "gs")
+        validators.validate_url(self.data_archive_upload_bucket, "data_archive_upload_bucket", "gs")
+        validators.validate_string(self.bucket_dir_path, "bucket_dir_path")
+
 
 class RawDataSource(ABC):
     @abstractmethod


### PR DESCRIPTION
Fixes for some small issues I found when adapting the new log uploading script for Ke-Urban. Including all fixes in one PR because they're small but happy to break down if easier or if any are controversial.

- Adds help text to 8_upload_log_files.sh
- Corrects references to memory_logs to data_archives where necessary.
- Updates validators to cover the new config options, including url validation.
- Pulls a list contains test out of a loop that was modifying that list.