### PR TITLE
Pre-filter out empty TracedData objects before running WS correction.

### DIFF
--- a/generate_outputs.py
+++ b/generate_outputs.py
@@ -77,9 +77,11 @@ if __name__ == "__main__":
     data = TranslateRapidProKeys.translate_rapid_pro_keys(user, data, pipeline_configuration)
 
     if pipeline_configuration.move_ws_messages:
-        log.info("Pre-filtering empty messages...")
+        log.info("Pre-filtering empty message objects...")
         # This is a performance optimisation to save execution time + memory when moving WS messages, by removing
-        # the need to mark and process a high volume of empty messages as 'NR' in WS correction.
+        # the need to mark and process a high volume of empty message objects as 'NR' in WS correction.
+        # Empty message objects represent flow runs where the participants never sent a message e.g. from an advert
+        # flow run where we asked someone a question but didn't receive a response.
         data = MessageFilters.filter_empty_messages(data,
                                                     [plan.raw_field for plan in PipelineConfiguration.RQA_CODING_PLANS])
 


### PR DESCRIPTION
This saves significant execution time + memory when moving WS messages by removing the need to mark and process a high volume of empty objects in WS correction. If an empty message object is passed into WS correction, it will be assigned an NR label, which takes a lot of time and memory on this project because there are so many empty objects (about 85% of runs contain no response, reflecting the advert response rate).

The left chart shows master pre-optimisation work, the right chart shows the combined results of this PR and #53, on the same scales for comparison:
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/7963608/90659592-c8066980-e23c-11ea-8c03-df3261a67582.png">

Note that the output CSVs from this PR differ in the ordering of the lines. The ordering was always arbitrary, and the change is just a side-effect of the pre-filter, so thing to be aware of but not concerned about. I confirmed the CSVs were the same before and after this change by sorting the files first, like this:
```
$ sort <old/individuals.csv >old/individuals-sorted.csv
$ sort <new/individuals.csv >new/individuals-sorted.csv
$ diff old/individuals.csv new/individuals.csv
$
```