### PR TITLE
Unload td history in automated analysis files

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -6,13 +6,11 @@ import sys
 
 import geopandas
 import matplotlib.pyplot as plt
-import plotly.express as px
 from core_data_modules.cleaners import Codes
 from core_data_modules.data_models.code_scheme import CodeTypes
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
 from core_data_modules.util import IOUtils
-
 
 from src import AnalysisUtils
 from configuration.code_schemes import  CodeSchemes
@@ -65,12 +63,16 @@ if __name__ == "__main__":
     log.info(f"Loading the messages dataset from {messages_json_input_path}...")
     with open(messages_json_input_path) as f:
         messages = TracedDataJsonIO.import_jsonl_to_traced_data_iterable(f)
+        for i in range (len(messages)):
+            messages[i] = dict(messages[i].items())
     log.info(f"Loaded {len(messages)} messages")
 
     # Read the individuals dataset
     log.info(f"Loading the individuals dataset from {individuals_json_input_path}...")
     with open(individuals_json_input_path) as f:
         individuals = TracedDataJsonIO.import_jsonl_to_traced_data_iterable(f)
+        for i in range (len(individuals)):
+            individuals[i] = dict(individuals[i].items())
     log.info(f"Loaded {len(individuals)} individuals")
 
     sys.setrecursionlimit(15000)


### PR DESCRIPTION
This unloads td history as earlier suggested. The first chart shows master pre-optimization memory profile maxing at 758 Mb, the second chart shows the result of this PR  maxing at 661 Mb run with a random sample of 2000 messages. As you had earlier mentioned this should have a significant improvement to the full pipeline run. The outputs are identical across both runs.
![image](https://user-images.githubusercontent.com/23135322/91165174-ebb42e80-e6d8-11ea-88a0-57f477dd64f1.png)
![image](https://user-images.githubusercontent.com/23135322/91165858-1b176b00-e6da-11ea-9f84-5cd2d325bd7a.png)
