### PR TITLE
add theme distribution to coding configuration

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None:
+                if cc.theme_distribution == Codes.FALSE:
                     continue
 
                 code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
@@ -214,7 +214,7 @@ if __name__ == "__main__":
         survey_counts["Total Participants %"] = None
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None or cc.code_scheme == CodeSchemes.AGE:
+                if cc.theme_distribution == Codes.FALSE:
                     continue
 
                 for code in cc.code_scheme.codes:
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     def update_survey_counts(survey_counts, td):
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None or cc.code_scheme == CodeSchemes.AGE:
+                if cc.theme_distribution == Codes.FALSE:
                     continue
 
                 if cc.coding_mode == CodingModes.SINGLE:
@@ -251,7 +251,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None or cc.code_scheme == CodeSchemes.AGE:
+                if cc.theme_distribution == Codes.FALSE:
                     continue
 
                 for code in cc.code_scheme.codes:

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.theme_distribution == Codes.FALSE:
+                if cc.include_in_theme_distribution == Codes.FALSE:
                     continue
 
                 code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
@@ -214,7 +214,7 @@ if __name__ == "__main__":
         survey_counts["Total Participants %"] = None
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.theme_distribution == Codes.FALSE:
+                if cc.include_in_theme_distribution == Codes.FALSE:
                     continue
 
                 for code in cc.code_scheme.codes:
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     def update_survey_counts(survey_counts, td):
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.theme_distribution == Codes.FALSE:
+                if cc.include_in_theme_distribution == Codes.FALSE:
                     continue
 
                 if cc.coding_mode == CodingModes.SINGLE:
@@ -251,7 +251,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.theme_distribution == Codes.FALSE:
+                if cc.include_in_theme_distribution == Codes.FALSE:
                     continue
 
                 for code in cc.code_scheme.codes:

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -298,7 +298,8 @@ def get_demog_coding_plans(pipeline_name):
                            cleaner=somali.DemographicCleaner.clean_gender,
                            coded_field="gender_coded",
                            analysis_file_key="gender",
-                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                           fold_strategy=FoldStrategies.assert_label_ids_equal,
+                           theme_distribution=Codes.TRUE
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("gender"),
@@ -314,14 +315,16 @@ def get_demog_coding_plans(pipeline_name):
                            cleaner=lambda text: clean_age_with_range_filter(text),
                            coded_field="age_coded",
                            analysis_file_key="age",
-                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                           fold_strategy=FoldStrategies.assert_label_ids_equal,
+                           theme_distribution=Codes.FALSE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
                            code_scheme=CodeSchemes.AGE_CATEGORY,
                            coded_field="age_category_coded",
                            analysis_file_key="age_category",
-                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                           fold_strategy=FoldStrategies.assert_label_ids_equal,
+                           theme_distribution=Codes.TRUE
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_age_category,
@@ -338,7 +341,8 @@ def get_demog_coding_plans(pipeline_name):
                            cleaner=somali.DemographicCleaner.clean_yes_no,
                            coded_field="recently_displaced_coded",
                            analysis_file_key="recently_displaced",
-                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                           fold_strategy=FoldStrategies.assert_label_ids_equal,
+                           theme_distribution=Codes.TRUE
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("recently displaced"),
@@ -353,7 +357,8 @@ def get_demog_coding_plans(pipeline_name):
                            code_scheme=CodeSchemes.HOUSEHOLD_LANGUAGE,
                            coded_field="household_language_coded",
                            analysis_file_key="household_language",
-                           fold_strategy=FoldStrategies.assert_label_ids_equal
+                           fold_strategy=FoldStrategies.assert_label_ids_equal,
+                           theme_distribution= Codes.TRUE
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("hh language"),
@@ -369,7 +374,8 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            cleaner=somali.DemographicCleaner.clean_mogadishu_sub_district,
                            coded_field="mogadishu_sub_district_coded",
-                           analysis_file_key="mogadishu_sub_district"
+                           analysis_file_key="mogadishu_sub_district",
+                           theme_distribution=Codes.FALSE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -377,7 +383,8 @@ def get_demog_coding_plans(pipeline_name):
                            cleaner=lambda text: clean_district_if_no_mogadishu_sub_district(text),
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="district_coded",
-                           analysis_file_key="district"
+                           analysis_file_key="district",
+                           theme_distribution=Codes.FALSE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -385,13 +392,15 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="region_coded",
                            analysis_file_key="region",
+                           theme_distribution=Codes.TRUE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
                            code_scheme=CodeSchemes.SOMALIA_STATE,
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="state_coded",
-                           analysis_file_key="state"
+                           analysis_file_key="state",
+                           theme_distribution=Codes.TRUE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -399,6 +408,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="zone_coded",
                            analysis_file_key="zone",
+                           theme_distribution=Codes.FALSE
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_somalia_location_codes,

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -299,7 +299,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="gender_coded",
                            analysis_file_key="gender",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           theme_distribution=Codes.TRUE
+                           include_in_theme_distribution=Codes.TRUE
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("gender"),
@@ -316,7 +316,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="age_coded",
                            analysis_file_key="age",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           theme_distribution=Codes.FALSE
+                           include_in_theme_distribution=Codes.FALSE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -324,7 +324,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="age_category_coded",
                            analysis_file_key="age_category",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           theme_distribution=Codes.TRUE
+                           include_in_theme_distribution=Codes.TRUE
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_age_category,
@@ -342,7 +342,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="recently_displaced_coded",
                            analysis_file_key="recently_displaced",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           theme_distribution=Codes.TRUE
+                           include_in_theme_distribution=Codes.TRUE
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("recently displaced"),
@@ -358,7 +358,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="household_language_coded",
                            analysis_file_key="household_language",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           theme_distribution= Codes.TRUE
+                           include_in_theme_distribution= Codes.TRUE
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("hh language"),
@@ -375,7 +375,7 @@ def get_demog_coding_plans(pipeline_name):
                            cleaner=somali.DemographicCleaner.clean_mogadishu_sub_district,
                            coded_field="mogadishu_sub_district_coded",
                            analysis_file_key="mogadishu_sub_district",
-                           theme_distribution=Codes.FALSE
+                           include_in_theme_distribution=Codes.FALSE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -384,7 +384,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="district_coded",
                            analysis_file_key="district",
-                           theme_distribution=Codes.FALSE
+                           include_in_theme_distribution=Codes.FALSE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -392,7 +392,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="region_coded",
                            analysis_file_key="region",
-                           theme_distribution=Codes.TRUE
+                           include_in_theme_distribution=Codes.TRUE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -400,7 +400,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="state_coded",
                            analysis_file_key="state",
-                           theme_distribution=Codes.TRUE
+                           include_in_theme_distribution=Codes.TRUE
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -408,7 +408,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="zone_coded",
                            analysis_file_key="zone",
-                           theme_distribution=Codes.FALSE
+                           include_in_theme_distribution=Codes.FALSE
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_somalia_location_codes,


### PR DESCRIPTION
This adds a theme_distribution boolean variable to help us add/remove surveys in the theme distribution file. Current config is what has been requested by RDA for this project.