### PR TITLE
update annonate() 's' arg to 'text'

### DIFF
--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -107,7 +107,7 @@ class MappingUtils(object):
                     xy = (admin_region[callout_position_columns[0]], admin_region[callout_position_columns[1]])
                     xytext = (admin_region[label_position_columns[0]], admin_region[label_position_columns[1]])
 
-                plt.annotate(s=frequencies[admin_region[admin_id_column]],
+                plt.annotate(text=frequencies[admin_region[admin_id_column]],
                              xy=xy, xytext=xytext,
                              arrowprops=dict(facecolor="black", arrowstyle="-", linewidth=0.1, shrinkA=0, shrinkB=0),
                              ha="center", va="center", fontsize=3.8)


### PR DESCRIPTION
The 's' parameter of annotate() has been renamed 'text' since Matplotlib 3.3; support for the old name will be dropped two minor releases later.
