### PR TITLE
Separate relevant maps from theme distribution maps

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -410,8 +410,12 @@ if __name__ == "__main__":
                                     dpi=1200, bbox_inches="tight")
                         plt.close()
 
-        if pipeline_configuration.automated_analysis.generate_region_theme_distribution_maps:
-            # Plot maps of each of the normal themes for this coding configuration.
+    # Plot maps of each of the normal themes for each coding plan if `generate_region_theme_distribution_maps`
+    # is set to True" in pipeline configuration.
+    if pipeline_configuration.automated_analysis.generate_region_theme_distribution_maps:
+        for rqa_plan in PipelineConfiguration.RQA_CODING_PLANS:
+            episode = episodes[rqa_plan.raw_field]
+
             for rqa_cc in rqa_plan.coding_configurations:
                 map_index = 2  # (index 1 was used in the total relevant map's filename).
                 for code in rqa_cc.code_scheme.codes:
@@ -477,8 +481,12 @@ if __name__ == "__main__":
                                     dpi=1200, bbox_inches="tight")
                         plt.close(fig)
 
-        if pipeline_configuration.automated_analysis.generate_district_theme_distribution_maps:
-            # Plot maps of each of the normal themes for this coding configuration.
+    # Plot maps of each of the normal themes for each coding plan if `generate_district_theme_distribution_maps`
+    # is set to True" in pipeline configuration.
+    if pipeline_configuration.automated_analysis.generate_district_theme_distribution_maps:
+        for rqa_plan in PipelineConfiguration.RQA_CODING_PLANS:
+            episode = episodes[rqa_plan.raw_field]
+
             for rqa_cc in rqa_plan.coding_configurations:
                 map_index = 2  # (index 1 was used in the total relevant map's filename).
                 for code in rqa_cc.code_scheme.codes:
@@ -503,8 +511,8 @@ if __name__ == "__main__":
                     plt.close(fig)
 
                     map_index += 1
-        log.info("Skipping generating a map of per-district theme participation because "
-                 "`generate_district_theme_distribution_maps` is set to False")
+    log.info("Skipping generating a map of per-district theme participation because "
+             "`generate_district_theme_distribution_maps` is set to False")
 
     log.info("Loading the Mogadishu sub-district geojson...")
     mogadishu_map = geopandas.read_file("geojson/mogadishu_sub_districts.geojson")
@@ -545,8 +553,12 @@ if __name__ == "__main__":
                                     dpi=1200, bbox_inches="tight")
                         plt.close(fig)
 
-        if pipeline_configuration.automated_analysis.generate_mogadishu_theme_distribution_maps:
-            # Plot maps of each of the normal themes for this coding configuration.
+    # Plot maps of each of the normal themes for each coding plan if `generate_mogadishu_theme_distribution_maps`
+    # is set to True" in pipeline configuration.
+    if pipeline_configuration.automated_analysis.generate_mogadishu_theme_distribution_maps:
+        for rqa_plan in PipelineConfiguration.RQA_CODING_PLANS:
+            episode = episodes[rqa_plan.raw_field]
+
             for rqa_cc in rqa_plan.coding_configurations:
                 map_index = 2  # (index 1 was used in the total relevant map's filename).
                 for code in rqa_cc.code_scheme.codes:
@@ -572,7 +584,7 @@ if __name__ == "__main__":
                     plt.close(fig)
 
                     map_index += 1
-        log.info("Skipping generating a map of mogadishu theme participation because "
-                 "`generate_mogadishu_theme_distribution_maps` is set to False")
+    log.info("Skipping generating a map of mogadishu theme participation because "
+             "`generate_mogadishu_theme_distribution_maps` is set to False")
 
     log.info("automated analysis python script complete")

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -394,7 +394,6 @@ if __name__ == "__main__":
                         continue
 
                     if survey_cc.include_in_theme_distribution == Codes.TRUE:
-
                         # Plot a map of the total relevant participants for this coding configuration.
                         rqa_total_region_frequencies = dict()
                         for region_code in CodeSchemes.SOMALIA_REGION.codes:

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -384,33 +384,41 @@ if __name__ == "__main__":
     plt.savefig(f"{automated_analysis_output_dir}/maps/regions/regions_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close()
 
-    for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        episode = episodes[plan.raw_field]
+    for rqa_plan in PipelineConfiguration.RQA_CODING_PLANS:
+        episode = episodes[rqa_plan.raw_field]
 
-        for cc in plan.coding_configurations:
-            # Plot a map of the total relevant participants for this coding configuration.
-            rqa_total_region_frequencies = dict()
-            for region_code in CodeSchemes.SOMALIA_REGION.codes:
-                if region_code.code_type == CodeTypes.NORMAL:
-                    rqa_total_region_frequencies[region_code.string_value] = \
-                        episode["Total Relevant Participants"][f"region:{region_code.string_value}"]
+        for rqa_cc in rqa_plan.coding_configurations:
+            for survey_plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+                for survey_cc in survey_plan.coding_configurations:
+                    if survey_cc.code_scheme != CodeSchemes.SOMALIA_REGION:
+                        continue
 
-            fig, ax = plt.subplots()
-            MappingUtils.plot_frequency_map(regions_map, "ADM1_AVF", rqa_total_region_frequencies,
-                                            label_position_columns=("ADM1_LX", "ADM1_LY"),
-                                            callout_position_columns=("ADM1_CALLX", "ADM1_CALLY"), ax=ax)
-            plt.savefig(f"{automated_analysis_output_dir}/maps/regions/region_{cc.analysis_file_key}_1_total_relevant.png",
-                        dpi=1200, bbox_inches="tight")
-            plt.close()
+                    if survey_cc.include_in_theme_distribution == Codes.TRUE:
 
-            if pipeline_configuration.automated_analysis.generate_region_theme_distribution_maps:
-                # Plot maps of each of the normal themes for this coding configuration.
+                        # Plot a map of the total relevant participants for this coding configuration.
+                        rqa_total_region_frequencies = dict()
+                        for region_code in CodeSchemes.SOMALIA_REGION.codes:
+                            if region_code.code_type == CodeTypes.NORMAL:
+                                rqa_total_region_frequencies[region_code.string_value] = \
+                                    episode["Total Relevant Participants"][f"region:{region_code.string_value}"]
+
+                        fig, ax = plt.subplots()
+                        MappingUtils.plot_frequency_map(regions_map, "ADM1_AVF", rqa_total_region_frequencies,
+                                                        label_position_columns=("ADM1_LX", "ADM1_LY"),
+                                                        callout_position_columns=("ADM1_CALLX", "ADM1_CALLY"), ax=ax)
+                        plt.savefig(f"{automated_analysis_output_dir}/maps/regions/region_{rqa_cc.analysis_file_key}_1_total_relevant.png",
+                                    dpi=1200, bbox_inches="tight")
+                        plt.close()
+
+        if pipeline_configuration.automated_analysis.generate_region_theme_distribution_maps:
+            # Plot maps of each of the normal themes for this coding configuration.
+            for rqa_cc in rqa_plan.coding_configurations:
                 map_index = 2  # (index 1 was used in the total relevant map's filename).
-                for code in cc.code_scheme.codes:
+                for code in rqa_cc.code_scheme.codes:
                     if code.code_type != CodeTypes.NORMAL:
                         continue
 
-                    theme = f"{cc.analysis_file_key}_{code.string_value}"
+                    theme = f"{rqa_cc.analysis_file_key}_{code.string_value}"
                     log.info(f"Generating a map of per-region participation for {theme}...")
                     demographic_counts = episode[theme]
 
@@ -424,13 +432,13 @@ if __name__ == "__main__":
                     MappingUtils.plot_frequency_map(regions_map, "ADM1_AVF", theme_region_frequencies,
                                                     label_position_columns=("ADM1_LX", "ADM1_LY"),
                                                     callout_position_columns=("ADM1_CALLX", "ADM1_CALLY"), ax=ax)
-                    plt.savefig(f"{automated_analysis_output_dir}/maps/regions/region_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
+                    plt.savefig(f"{automated_analysis_output_dir}/maps/regions/region_{rqa_cc.analysis_file_key}_{map_index}_{code.string_value}.png",
                                 dpi=1200, bbox_inches="tight")
                     plt.close()
 
                     map_index += 1
-            log.info("Skipping generating a map of per-region theme participation because "
-                     "`generate_region_theme_distribution_maps` is set to False")
+        log.info("Skipping generating a map of per-region theme participation because "
+                 "`generate_region_theme_distribution_maps` is set to False")
 
     log.info("Loading the Somalia districts geojson...")
     districts_map = geopandas.read_file("geojson/somalia_districts.geojson")
@@ -446,32 +454,38 @@ if __name__ == "__main__":
     plt.savefig(f"{automated_analysis_output_dir}/maps/districts/district_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close(fig)
 
+    for rqa_plan in PipelineConfiguration.RQA_CODING_PLANS:
+        episode = episodes[rqa_plan.raw_field]
 
-    for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        episode = episodes[plan.raw_field]
+        for rqa_cc in rqa_plan.coding_configurations:
+            for survey_plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+                for survey_cc in survey_plan.coding_configurations:
+                    if survey_cc.code_scheme != CodeSchemes.SOMALIA_DISTRICT:
+                        continue
+                    if survey_cc.include_in_theme_distribution == Codes.TRUE:
 
-        for cc in plan.coding_configurations:
-            # Plot a map of the total relevant participants for this coding configuration.
-            rqa_total_district_frequencies = dict()
-            for district_code in CodeSchemes.SOMALIA_DISTRICT.codes:
-                if district_code.code_type == CodeTypes.NORMAL:
-                    rqa_total_district_frequencies[district_code.string_value] = \
-                        episode["Total Relevant Participants"][f"district:{district_code.string_value}"]
+                        # Plot a map of the total relevant participants for this coding configuration.
+                        rqa_total_district_frequencies = dict()
+                        for district_code in CodeSchemes.SOMALIA_DISTRICT.codes:
+                            if district_code.code_type == CodeTypes.NORMAL:
+                                rqa_total_district_frequencies[district_code.string_value] = \
+                                    episode["Total Relevant Participants"][f"district:{district_code.string_value}"]
 
-            fig, ax = plt.subplots()
-            MappingUtils.plot_frequency_map(districts_map, "ADM2_AVF", rqa_total_district_frequencies, ax=ax)
-            plt.savefig(f"{automated_analysis_output_dir}/maps/districts/district_{cc.analysis_file_key}_1_total_relevant.png",
-                        dpi=1200, bbox_inches="tight")
-            plt.close(fig)
+                        fig, ax = plt.subplots()
+                        MappingUtils.plot_frequency_map(districts_map, "ADM2_AVF", rqa_total_district_frequencies, ax=ax)
+                        plt.savefig(f"{automated_analysis_output_dir}/maps/districts/district_{rqa_cc.analysis_file_key}_1_total_relevant.png",
+                                    dpi=1200, bbox_inches="tight")
+                        plt.close(fig)
 
-            if pipeline_configuration.automated_analysis.generate_district_theme_distribution_maps:
-                # Plot maps of each of the normal themes for this coding configuration.
+        if pipeline_configuration.automated_analysis.generate_district_theme_distribution_maps:
+            # Plot maps of each of the normal themes for this coding configuration.
+            for rqa_cc in rqa_plan.coding_configurations:
                 map_index = 2  # (index 1 was used in the total relevant map's filename).
-                for code in cc.code_scheme.codes:
+                for code in rqa_cc.code_scheme.codes:
                     if code.code_type != CodeTypes.NORMAL:
                         continue
 
-                    theme = f"{cc.analysis_file_key}_{code.string_value}"
+                    theme = f"{rqa_cc.analysis_file_key}_{code.string_value}"
                     log.info(f"Generating a map of per-district participation for {theme}...")
                     demographic_counts = episode[theme]
 
@@ -484,13 +498,13 @@ if __name__ == "__main__":
                     fig, ax = plt.subplots()
                     MappingUtils.plot_frequency_map(districts_map, "ADM2_AVF", theme_district_frequencies, ax=ax)
                     plt.savefig(
-                        f"{automated_analysis_output_dir}/maps/districts/district_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
+                        f"{automated_analysis_output_dir}/maps/districts/district_{rqa_cc.analysis_file_key}_{map_index}_{code.string_value}.png",
                         dpi=1200, bbox_inches="tight")
                     plt.close(fig)
 
                     map_index += 1
-            log.info("Skipping generating a map of per-district theme participation because "
-                     "`generate_district_theme_distribution_maps` is set to False")
+        log.info("Skipping generating a map of per-district theme participation because "
+                 "`generate_district_theme_distribution_maps` is set to False")
 
     log.info("Loading the Mogadishu sub-district geojson...")
     mogadishu_map = geopandas.read_file("geojson/mogadishu_sub_districts.geojson")
@@ -508,32 +522,38 @@ if __name__ == "__main__":
     plt.savefig(f"{automated_analysis_output_dir}/maps/mogadishu/mogadishu_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close(fig)
 
-    for plan in PipelineConfiguration.RQA_CODING_PLANS:
-        episode = episodes[plan.raw_field]
+    for rqa_plan in PipelineConfiguration.RQA_CODING_PLANS:
+        episode = episodes[rqa_plan.raw_field]
+        for rqa_cc in rqa_plan.coding_configurations:
+            for survey_plan in PipelineConfiguration.SURVEY_CODING_PLANS:
+                for survey_cc in survey_plan.coding_configurations:
+                    if survey_cc.code_scheme != CodeSchemes.MOGADISHU_SUB_DISTRICT:
+                        continue
+                    if  survey_cc.include_in_theme_distribution == Codes.TRUE:
 
-        for cc in plan.coding_configurations:
-            # Plot a map of the total relevant participants for this coding configuration.
-            rqa_total_mogadishu_frequencies = dict()
-            for sub_district_code in CodeSchemes.MOGADISHU_SUB_DISTRICT.codes:
-                if sub_district_code.code_type == CodeTypes.NORMAL:
-                    rqa_total_mogadishu_frequencies[sub_district_code.string_value] = \
-                        episode["Total Relevant Participants"][f"mogadishu_sub_district:{sub_district_code.string_value}"]
+                        # Plot a map of the total relevant participants for this coding configuration.
+                        rqa_total_mogadishu_frequencies = dict()
+                        for sub_district_code in CodeSchemes.MOGADISHU_SUB_DISTRICT.codes:
+                            if sub_district_code.code_type == CodeTypes.NORMAL:
+                                rqa_total_mogadishu_frequencies[sub_district_code.string_value] = \
+                                    episode["Total Relevant Participants"][f"mogadishu_sub_district:{sub_district_code.string_value}"]
 
-            fig, ax = plt.subplots()
-            MappingUtils.plot_frequency_map(mogadishu_map, "ADM3_AVF", rqa_total_mogadishu_frequencies, ax=ax,
-                                            label_position_columns=("ADM3_LX", "ADM3_LY"))
-            plt.savefig(f"{automated_analysis_output_dir}/maps/mogadishu/mogadishu_{cc.analysis_file_key}_1_total_relevant.png",
-                        dpi=1200, bbox_inches="tight")
-            plt.close(fig)
+                        fig, ax = plt.subplots()
+                        MappingUtils.plot_frequency_map(mogadishu_map, "ADM3_AVF", rqa_total_mogadishu_frequencies, ax=ax,
+                                                        label_position_columns=("ADM3_LX", "ADM3_LY"))
+                        plt.savefig(f"{automated_analysis_output_dir}/maps/mogadishu/mogadishu_{rqa_cc.analysis_file_key}_1_total_relevant.png",
+                                    dpi=1200, bbox_inches="tight")
+                        plt.close(fig)
 
-            if pipeline_configuration.automated_analysis.generate_mogadishu_theme_distribution_maps:
-                # Plot maps of each of the normal themes for this coding configuration.
+        if pipeline_configuration.automated_analysis.generate_mogadishu_theme_distribution_maps:
+            # Plot maps of each of the normal themes for this coding configuration.
+            for rqa_cc in rqa_plan.coding_configurations:
                 map_index = 2  # (index 1 was used in the total relevant map's filename).
-                for code in cc.code_scheme.codes:
+                for code in rqa_cc.code_scheme.codes:
                     if code.code_type != CodeTypes.NORMAL:
                         continue
 
-                    theme = f"{cc.analysis_file_key}_{code.string_value}"
+                    theme = f"{rqa_cc.analysis_file_key}_{code.string_value}"
                     log.info(f"Generating a map of Mogadishu participation for {theme}...")
                     demographic_counts = episode[theme]
 
@@ -547,12 +567,12 @@ if __name__ == "__main__":
                     MappingUtils.plot_frequency_map(mogadishu_map, "ADM3_AVF", mogadishu_theme_frequencies, ax=ax,
                                                     label_position_columns=("ADM3_LX", "ADM3_LY"))
                     plt.savefig(
-                        f"{automated_analysis_output_dir}/maps/mogadishu/mogadishu_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
+                        f"{automated_analysis_output_dir}/maps/mogadishu/mogadishu_{rqa_cc.analysis_file_key}_{map_index}_{code.string_value}.png",
                         dpi=1200, bbox_inches="tight")
                     plt.close(fig)
 
                     map_index += 1
-            log.info("Skipping generating a map of mogadishu theme participation because "
-                     "`generate_mogadishu_theme_distribution_maps` is set to False")
+        log.info("Skipping generating a map of mogadishu theme participation because "
+                 "`generate_mogadishu_theme_distribution_maps` is set to False")
 
     log.info("automated analysis python script complete")

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -32,18 +32,18 @@ echo "Starting run with id '$RUN_ID'"
 
 #./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
-    "$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+#./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
+    #"$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+#./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-#if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
-   #./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
-#fi
+if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
+   ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+fi
 
-#./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
+./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
 
 ./7_upload_analysis_files.sh "$USER" "$PIPELINE_RUN_MODE" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
     "$RUN_ID" "$DATA_ROOT"
 
-#./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"
+./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -28,22 +28,22 @@ RUN_ID="$DATE-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+#./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+#./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
 ./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
     "$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
 ./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
-   ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
-fi
+#if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
+   #./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+#fi
 
-./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
+#./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
 
 ./7_upload_analysis_files.sh "$USER" "$PIPELINE_RUN_MODE" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
     "$RUN_ID" "$DATA_ROOT"
 
-./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"
+#./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -28,14 +28,14 @@ RUN_ID="$DATE-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-#./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-#./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-#./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
-    #"$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
+    "$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-#./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
 if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
    ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"


### PR DESCRIPTION
RDA uses all total_relevant maps for all locations but not theme distribution maps for all locations. This separates the code blocks that generate both maps so that we can switch configurations on which one to generate independently. 