### PR TITLE
Enable incremental get from coda

### DIFF
--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -47,13 +47,21 @@ DATASETS=(
 )
 
 cd "$CODA_V2_ROOT/data_tools"
-git checkout "94a55d9218fb072ef2c15ee2c27c4214b036bd2f"  # (master which supports LastUpdated)
+git checkout "e895887b3abceb63bab672a262d5c1dd73dcad92"  # (master which supports incremental get)
 
 mkdir -p "$DATA_ROOT/Coded Coda Files"
 
 for DATASET in ${DATASETS[@]}
 do
-    echo "Getting messages data from ${DATASET}..."
+    FILE="$DATA_ROOT/Coded Coda Files/$DATASET.json"
 
-    pipenv run python get.py "$AUTH" "${DATASET}" messages >"$DATA_ROOT/Coded Coda Files/$DATASET.json"
+    if [ -e "$FILE" ]; then
+        echo "Getting messages data from ${DATASET} (incremental update)..."
+        MESSAGES=$(pipenv run python get.py --previous-export-file-path "$FILE" "$AUTH" "${DATASET}" messages)
+        echo "$MESSAGES" >"$FILE"
+    else
+        echo "Getting messages data from ${DATASET} (full download)..."
+        pipenv run python get.py "$AUTH" "${DATASET}" messages >"$FILE"
+    fi
+
 done

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -45,7 +45,7 @@ DATASETS=(
 )
 
 cd "$CODA_V2_ROOT/data_tools"
-git checkout "94a55d9218fb072ef2c15ee2c27c4214b036bd2f"  # (master which supports LastUpdated)
+git checkout "e895887b3abceb63bab672a262d5c1dd73dcad92"  # (master which supports incremental get)
 
 for DATASET in ${DATASETS[@]}
 do


### PR DESCRIPTION
Tested manually when developing the changes to data tools, and then against imaqal by running the get script several times at intervals over the last few days and checking that the resulting files match the datasets in Coda when retrieved non-incrementally. I think we've done all the small-scale local testing we can, but because the risk of us getting this wrong is that we lose data in analysis, I would suggest occasional verification against Coda initially. I have a validation script I can submit in a PR against data_tools if it helps. 

Also note that the incremental get script is conservative about when it attempts an incremental get - it will only get incrementally if the previous export contains a "LastUpdated" field (and will warn you if it doesn't). You might need to un-check and check a label in Coda to "kick" the old datasets into incremental mode.