### PR TITLE
Fix demog distribution keys

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -173,7 +173,7 @@ if __name__ == "__main__":
             for code in cc.code_scheme.codes:
                 if code.control_code == Codes.STOP:
                     continue
-                demographic_distributions[cc.analysis_file_key][code.code_id] = 0
+                demographic_distributions[cc.analysis_file_key][code.string_value] = 0
             total_relevant[cc.analysis_file_key] = 0
 
     for ind in individuals:
@@ -187,7 +187,7 @@ if __name__ == "__main__":
 
                 assert cc.coding_mode == CodingModes.SINGLE
                 code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
-                demographic_distributions[cc.analysis_file_key][code.code_id] += 1
+                demographic_distributions[cc.analysis_file_key][code.string_value] += 1
                 if code.code_type == CodeTypes.NORMAL:
                     total_relevant[cc.analysis_file_key] += 1
 
@@ -198,7 +198,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None:
+                if cc.analysis_file_key is None or cc.include_in_theme_distribution == Codes.FALSE:
                     continue
 
                 for i, code in enumerate(cc.code_scheme.codes):
@@ -207,7 +207,7 @@ if __name__ == "__main__":
                     if code.control_code == Codes.STOP:
                         continue
 
-                    participants_with_opt_ins = demographic_distributions[cc.analysis_file_key][code.code_id]
+                    participants_with_opt_ins = demographic_distributions[cc.analysis_file_key][code.string_value]
                     row = {
                         "Demographic": cc.analysis_file_key if i == 0 else "",
                         "Code": code.string_value,

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None or cc.include_in_theme_distribution == Codes.FALSE:
+                if cc.analysis_file_key is None or cc.include_in_theme_distribution == False:
                     continue
 
                 assert cc.coding_mode == CodingModes.SINGLE
@@ -198,7 +198,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.DEMOG_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.analysis_file_key is None or cc.include_in_theme_distribution == Codes.FALSE:
+                if cc.analysis_file_key is None or cc.include_in_theme_distribution == False:
                     continue
 
                 for i, code in enumerate(cc.code_scheme.codes):

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -130,7 +130,6 @@ def get_rqa_coding_plans(pipeline_name):
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 s01e04"),
                    raw_field_fold_strategy=FoldStrategies.concatenate),
-
         CodingPlan(raw_field="rqa_covid19_mag_s01e05_raw",
                    time_field="sent_on",
                    run_id_field="rqa_covid19_mag_s01e05_run_id",
@@ -198,7 +197,7 @@ def get_rqa_coding_plans(pipeline_name):
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 s01e08"),
                    raw_field_fold_strategy=FoldStrategies.concatenate),
-        
+
         CodingPlan(raw_field="rqa_covid19_mag_s01e09_raw",
                    time_field="sent_on",
                    run_id_field="rqa_covid19_mag_s01e09_run_id",
@@ -281,7 +280,8 @@ def get_rqa_coding_plans(pipeline_name):
                            fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DIAGNOSTIC_S01E03, x, y)
                        )
                    ],
-                   ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 diagnostic s01e03"),
+                   ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value(
+                       "imaqal covid19 diagnostic s01e03"),
                    raw_field_fold_strategy=FoldStrategies.concatenate),
 
         CodingPlan(raw_field="rqa_covid19_mag_s01e13_raw",
@@ -419,7 +419,6 @@ def get_rqa_coding_plans(pipeline_name):
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 s01e20"),
                    raw_field_fold_strategy=FoldStrategies.concatenate),
-
         CodingPlan(raw_field="rqa_covid19_mag_s01e21_raw",
                    time_field="sent_on",
                    run_id_field="rqa_covid19_mag_s01e21_run_id",
@@ -453,8 +452,7 @@ def get_rqa_coding_plans(pipeline_name):
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("imaqal covid19 s01e22"),
                    raw_field_fold_strategy=FoldStrategies.concatenate),
-    ]
-
+]
 
 def get_demog_coding_plans(pipeline_name):
     return [
@@ -469,7 +467,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="gender_coded",
                            analysis_file_key="gender",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           include_in_theme_distribution=Codes.TRUE
+                           include_in_theme_distribution= True
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("gender"),
@@ -486,7 +484,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="age_coded",
                            analysis_file_key="age",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           include_in_theme_distribution=Codes.FALSE
+                           include_in_theme_distribution= False
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -494,7 +492,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="age_category_coded",
                            analysis_file_key="age_category",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           include_in_theme_distribution=Codes.TRUE
+                           include_in_theme_distribution= True
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_age_category,
@@ -512,7 +510,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="recently_displaced_coded",
                            analysis_file_key="recently_displaced",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           include_in_theme_distribution=Codes.TRUE
+                           include_in_theme_distribution= True
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("recently displaced"),
@@ -528,7 +526,7 @@ def get_demog_coding_plans(pipeline_name):
                            coded_field="household_language_coded",
                            analysis_file_key="household_language",
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
-                           include_in_theme_distribution= Codes.TRUE
+                           include_in_theme_distribution= True
                        )
                    ],
                    ws_code=CodeSchemes.WS_CORRECT_DATASET_SCHEME.get_code_with_match_value("hh language"),
@@ -545,7 +543,7 @@ def get_demog_coding_plans(pipeline_name):
                            cleaner=somali.DemographicCleaner.clean_mogadishu_sub_district,
                            coded_field="mogadishu_sub_district_coded",
                            analysis_file_key="mogadishu_sub_district",
-                           include_in_theme_distribution=Codes.FALSE
+                           include_in_theme_distribution= False
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -554,7 +552,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="district_coded",
                            analysis_file_key="district",
-                           include_in_theme_distribution=Codes.FALSE
+                           include_in_theme_distribution= False
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -562,7 +560,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="region_coded",
                            analysis_file_key="region",
-                           include_in_theme_distribution=Codes.TRUE
+                           include_in_theme_distribution= True
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -570,7 +568,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="state_coded",
                            analysis_file_key="state",
-                           include_in_theme_distribution=Codes.TRUE
+                           include_in_theme_distribution= True
                        ),
                        CodingConfiguration(
                            coding_mode=CodingModes.SINGLE,
@@ -578,7 +576,7 @@ def get_demog_coding_plans(pipeline_name):
                            fold_strategy=FoldStrategies.assert_label_ids_equal,
                            coded_field="zone_coded",
                            analysis_file_key="zone",
-                           include_in_theme_distribution=Codes.FALSE
+                           include_in_theme_distribution= False
                        )
                    ],
                    code_imputation_function=code_imputation_functions.impute_somalia_location_codes,

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -28,22 +28,22 @@ RUN_ID="$DATE-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+#./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+#./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
-    "$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+#./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
+    #"$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+#./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
-   ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
-fi
+#if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
+   #./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+#fi
 
-./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
+#./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
 
 ./7_upload_analysis_files.sh "$USER" "$PIPELINE_RUN_MODE" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
     "$RUN_ID" "$DATA_ROOT"
 
-./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"
+#./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -28,22 +28,22 @@ RUN_ID="$DATE-$HASH"
 
 echo "Starting run with id '$RUN_ID'"
 
-#./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+./1_coda_get.sh "$CODA_PULL_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-#./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+./2_fetch_raw_data.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-#./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
-    #"$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+./3_generate_outputs.sh --profile-memory "$PERFORMANCE_LOGS_DIR/memory-$RUN_ID.profile" \
+    "$USER" "$PIPELINE_RUN_MODE" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 
-#./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
+./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
 if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
    ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
 fi
 
-#./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
+./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
 
 ./7_upload_analysis_files.sh "$USER" "$PIPELINE_RUN_MODE" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" \
     "$RUN_ID" "$DATA_ROOT"
 
-#./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"
+./8_upload_log_files.sh "$USER" "$AVF_BUCKET_CREDENTIALS_PATH" "$PIPELINE_CONFIGURATION" "$PERFORMANCE_LOGS_DIR" "$DATA_BACKUPS_DIR"

--- a/run_scripts/run_pipeline.sh
+++ b/run_scripts/run_pipeline.sh
@@ -37,9 +37,9 @@ echo "Starting run with id '$RUN_ID'"
 
 #./4_coda_add.sh "$CODA_PUSH_CREDENTIALS_PATH" "$CODA_TOOLS_ROOT" "$DATA_ROOT"
 
-#if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
-   #./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
-#fi
+if [[ $PIPELINE_RUN_MODE == "all-stages" ]]; then
+   ./5_automated_analysis.sh --profile-memory "$PERFORMANCE_LOGS_DIR/automated-analysis-memory-$RUN_ID.profile" "$USER" "$PIPELINE_CONFIGURATION" "$DATA_ROOT"
+fi
 
 #./6_backup_data_root.sh "$DATA_ROOT" "$DATA_BACKUPS_DIR/data-$RUN_ID.tar.gzip"
 


### PR DESCRIPTION
Participation maps reference string_values from demog distribution dict. This updates demog distribution to use string_values instead of code_id.